### PR TITLE
Update image name for gml-web-frontend in docker-compose-prod.yml file

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -72,7 +72,7 @@ services:
     environment: *default-environment
 
   gml-web-frontend:
-    image: ghcr.io/scondic/gml.web.client:master
+    image: gml-web-frontend
     container_name: gml-frontend
     restart: always
     build:


### PR DESCRIPTION
In the docker-compose-prod.yml file, the image name for the 'gml-web-frontend' service has been updated from 'ghcr.io/scondic/gml.web.client:master' to 'gml-web-frontend'. This change will ensure that the correct image is used when running the service.