### PR TITLE
Renamed services in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     image: redis
     restart: unless-stopped
 
-  web:
+  glitchtip-web:
     image: glitchtip/glitchtip
     depends_on: *default-depends_on
     ports:
@@ -69,7 +69,7 @@ services:
     volumes:
       - uploads:/code/uploads
 
-  worker:
+  glitchtip-worker:
     image: glitchtip/glitchtip
     command: ./bin/run-celery-with-beat.sh
     depends_on: *default-depends_on
@@ -78,7 +78,7 @@ services:
     volumes:
       - uploads:/code/uploads
 
-  migrate:
+  glitchtip-migrate:
     image: glitchtip/glitchtip
     depends_on: *default-depends_on
     command: "./manage.py migrate"


### PR DESCRIPTION
The existing identity "web", "worker", and "migrate" services within the docker-compose.yml have been renamed to "glitchtip-web", "glitchtip-worker", and "glitchtip-migrate". This change specifies more clear service identifiers, enhancing maintainability and understandability.